### PR TITLE
Unit Test Support

### DIFF
--- a/src/main/java/frc/robot/utilities/DebugTable.java
+++ b/src/main/java/frc/robot/utilities/DebugTable.java
@@ -3,10 +3,11 @@ package frc.robot.utilities;
 import java.lang.Object;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.NetworkTableValue;
 
 public class DebugTable {
     static NetworkTable NetTabInst = NetworkTableInstance.getDefault().getTable("Debug");
-    public static Object get(String DataName) {
+    public static NetworkTableValue get(String DataName) {
         return NetTabInst.getValue(DataName);
     };
 

--- a/src/test/java/DebugTest.java
+++ b/src/test/java/DebugTest.java
@@ -1,12 +1,26 @@
-import frc.robot.utilities.DebugTable;
-// Optional Test for DebugValue located in commands directory. (Can be removed as well as the directory if not wanted)
-public class DebugTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-    public void Test() {
-        String DataName = "TestValue";
-        System.out.println(DebugTable.get(DataName));
-    
-        DebugTable.set(DataName, 2);
-        System.out.println(DebugTable.get(DataName));
+import org.junit.jupiter.api.Test;
+
+import frc.robot.utilities.DebugTable;
+
+public class DebugTest {
+    @Test
+    public void createDoubleTest() {
+        DebugTable.set("AAA", 1.1);
+        assertEquals(DebugTable.get("AAA").getDouble(), 1.1);
+    }
+
+    @Test
+    public void getNoSetTest() {
+        assertNull(DebugTable.get("BBB").getValue());
+    }
+
+    @Test
+    public void getSetGetTest() {
+        assertNull(DebugTable.get("CCC").getValue());
+        DebugTable.set("CCC", "test");
+        assertEquals(DebugTable.get("CCC").getString(), "test");
     }
 }


### PR DESCRIPTION
Created complete tests for the DebugTable class as a template for possible future unit tests.

This also modifies the DebugTable class so that it returns a NetworkTableValue instead of a pure java Object. Every time we attempted to get() and cast, it threw a ClassCastException.